### PR TITLE
Improve dependency handling on Linux (save time, ignore errors, !linux-amd64 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,9 @@ jobs:
       -
         name: Dump context
         uses: ./
+      -
+        if: ${{ runner.os == 'Linux' }}
+        # run a 2nd time on Linux to see how the action behaves
+        # after the 1st run already installed missing dependencies
+        name: 2nd Dump context
+        uses: ./

--- a/action.yml
+++ b/action.yml
@@ -61,18 +61,25 @@ runs:
           });
 
           if (`${process.env.RUNNER_OS}` == 'Linux') {
-            await core.group(`Install deps`, async () => {
-              const sudo = await exec.getExecOutput('which sudo', [], {silent: true, ignoreReturnCode: true})
-              if (sudo.stdout != "") {
-                const aptget = await exec.getExecOutput('which apt-get', [], {silent: true, ignoreReturnCode: true})
-                if (aptget.stdout != "") {
-                  await exec.exec('sudo apt-get update');
-                  await exec.exec('sudo apt-get install -y cgroup-tools cpuid');
+            await core.group(`Check/install deps`, async () => {
+              const required_cmds = (`${process.env.RUNNER_ARCH}` == 'X64') ? ["lscgroup", "cpuid"] : ["lscgroup"];
+              try {
+                await exec.exec('which', required_cmds);
+              } catch (error) {
+                core.info("Installing deps...");
+                const sudo = await exec.getExecOutput('which sudo', [], {silent: true, ignoreReturnCode: true})
+                if (sudo.stdout != "") {
+                  const aptget = await exec.getExecOutput('which apt-get', [], {silent: true, ignoreReturnCode: true})
+                  if (aptget.stdout != "") {
+                    await exec.exec('sudo', ['apt-get', 'update'], {ignoreReturnCode: true});
+                    const required_deps = (`${process.env.RUNNER_ARCH}` == 'X64') ? ["cgroup-tools", "cpuid"] : ["cgroup-tools"];
+                    await exec.exec('sudo', ['apt-get', 'install', '-y'].concat(required_deps), {ignoreReturnCode: true});
+                  } else {
+                    core.info('apt-get not found; not installing deps')
+                  }
                 } else {
-                  core.info('apt-get not found; not installing deps')
+                  core.info('sudo not found; not installing deps')
                 }
-              } else {
-                core.info('sudo not found; not installing deps')
               }
             });
             await core.group(`Print cpuinfo`, async () => {


### PR DESCRIPTION
* Only do the apt-get calls on Linux when dependencies are actually missing to save some seconds on private runners, which have the dependencies all installed.
* Ensure apt-get failures do not stop the action, by running the apt-get calls with `{ignoreReturnCode: true}`.
* Only install cpuid on linux-amd64 aka x86_64, as it is only available on linux-amd64 (not e.g. on linux-aarch64), see https://packages.ubuntu.com/jammy/cpuid ... (this caused the action to stop on self hosted linux-aarch64 runners)